### PR TITLE
fix: add vercel.json with cleanUrls

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Summary
- 直接URLアクセス時に記事ページが404になる問題を修正
- Vercelの `cleanUrls` 設定を追加し、`.html` なしのURLでも正しくルーティングされるようにした

## Test plan
- [x] Vercelプレビューで `/posts/2026/02/migrate-to-vitepress` に直接アクセスして本文が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)