### PR TITLE
fix: yaml パッケージの脆弱性を overrides で解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8513,18 +8513,6 @@
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
     },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,10 @@
     "pagefind": "^1.3.0",
     "vite-plugin-pagefind": "^1.0.7"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "yaml-language-server": {
+      "yaml": "2.8.3"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `yaml-language-server` が依存する `yaml@2.7.1` にスタックオーバーフローの脆弱性 (GHSA-48c2-rrv3-qjmp) があった
- `package.json` に `overrides` を追加し、`yaml@2.8.3` に強制更新して解消
- `npm audit` の脆弱性 5件 → 0件

## Test plan
- [x] `npm audit` で脆弱性が 0 件であることを確認
- [x] `npm run build` (`astro check && astro build && pagefind`) が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)