### PR TITLE
ci: Dependabot 設定を追加（週次・グループ化）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- npm と github-actions の依存関係を週1回チェックする Dependabot 設定を追加
- `groups` で全更新を1PRにまとめるよう設定

## Test plan
- [ ] マージ後、Dependabot が有効化されることを確認
- [ ] 依存関係の更新PRがグループ化されて作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)