### PR TITLE
ci: lint.yml の runner を ubuntu-slim に変更

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-slim
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04-slim
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- lint.yml の `runs-on` を `ubuntu-latest` から `ubuntu-slim` に変更
- slim イメージは不要なプリインストールツールが省かれており、ジョブの起動が高速化される

## Test plan
- [x] GitHub Actions の lint ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)