### PR TITLE
style: 日本語と英数字の間に text-autospace で余白を追加

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,6 @@
 @plugin "@tailwindcss/forms";
 @config "../../tailwind.config.mjs";
 
-.prose {
+body {
   text-autospace: normal;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,3 +2,7 @@
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/forms";
 @config "../../tailwind.config.mjs";
+
+.prose {
+  text-autospace: normal;
+}


### PR DESCRIPTION
## Summary

- ブログ記事内で日本語と英単語/数字が混在した際の字間が詰まって読みにくかったため、`.prose` に `text-autospace: normal` を指定してブラウザネイティブで自動的に余白が入るようにした
- `.prose` は \`src/layouts/ProseWrapper.astro\` 経由で全ブログ記事本文に適用される

## Test plan

- [x] http://localhost:4321/posts/2026/04/migrate-to-astro を開き、日本語と英単語の境界に余白が入ることを確認
- [x] CI がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)