### PR TITLE
feat: ブログ記事の雛形を生成する add-post.mjs を追加

### DIFF
--- a/add-post.mjs
+++ b/add-post.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// add-post.mjs - Create a new blog post
+// Usage: node add-post.mjs "My Post Title"
+//        or:  ./add-post.mjs "My Post Title"
+import { mkdirSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+function titleToSlug(title) {
+  return title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+// --- メイン処理 ---
+const title = process.argv[2];
+
+if (!title) {
+  console.error("Usage: node add-post.mjs [title]");
+  process.exit(1);
+}
+
+const now = new Date();
+const year = String(now.getFullYear());
+const month = String(now.getMonth() + 1).padStart(2, "0");
+const day = String(now.getDate()).padStart(2, "0");
+const slug = titleToSlug(title) || `${year}-${month}-${day}`;
+const pubDate = `${year}-${month}-${day}T${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+
+const dir = join("src", "content", "blog", year, month);
+const filePath = join(dir, `${slug}.mdx`);
+
+if (existsSync(filePath)) {
+  console.error(`Error: ${filePath} already exists`);
+  process.exit(1);
+}
+
+mkdirSync(dir, { recursive: true });
+
+const content = `---
+title: "${title}"
+description: ""
+pubDate: "${pubDate}"
+published: true
+tags: []
+---
+`;
+
+writeFileSync(filePath, content);
+console.log(`Created: ${filePath}`);

--- a/add-post.mjs
+++ b/add-post.mjs
@@ -13,7 +13,8 @@ function titleToSlug(title) {
     .replace(/[^\w\s-]/g, "")
     .trim()
     .replace(/[\s_]+/g, "-")
-    .replace(/-+/g, "-");
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 // --- メイン処理 ---


### PR DESCRIPTION
## Summary
- `node add-post.mjs [title]` で `src/content/blog/YYYY/MM/slug.mdx` を frontmatter 付きで自動生成するスクリプトを追加
- タイトルを kebab-case の slug に変換し、日本語のみのタイトルの場合は日付ベースのファイル名にフォールバック
- 既存ファイルとの重複チェック付き

## Test plan
- [x] `node add-post.mjs "My First Post"` → `my-first-post.mdx` が生成される
- [x] `node add-post.mjs "テスト記事"` → `2026-04-12.mdx` が生成される
- [x] 引数なしで実行 → エラーメッセージが表示される
- [x] 同名ファイルが存在する場合 → エラーで中断される

🤖 Generated with [Claude Code](https://claude.com/claude-code)