### PR TITLE
fix: tsconfig.jsonから非推奨のbaseUrlを削除

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         $pages: resolve("./src/pages"),
         $assets: resolve("./src/assets"),
         $content: resolve("./src/content"),
+        "src/embeds": resolve("./src/embeds"),
       },
     },
     ssr: {

--- a/src/layouts/ProseWrapper.astro
+++ b/src/layouts/ProseWrapper.astro
@@ -1,5 +1,5 @@
 ---
-import { colorBaseClasses, colorAccentClasses } from "src/colors";
+import { colorBaseClasses, colorAccentClasses } from "../colors";
 import { ACCENT_COLOR, BASE_COLOR } from "../config.ts";
 
 const { class: className } = Astro.props;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import { POSTS_PER_PAGE } from "../config.ts";
-import { getBlogPosts } from "src/utils";
+import { getBlogPosts } from "../utils";
 import PostList from "$layouts/PostList.astro";
 
 const posts = (await getBlogPosts()).splice(0, POSTS_PER_PAGE);

--- a/src/pages/open-graph/[...route].ts
+++ b/src/pages/open-graph/[...route].ts
@@ -1,6 +1,6 @@
 import { OGImageRoute } from "astro-og-canvas";
 import { ACCENT_COLOR, BASE_COLOR, SITE_DESCRIPTION, SITE_TITLE } from "../../config.ts";
-import { getBlogPosts } from "src/utils";
+import { getBlogPosts } from "../../utils";
 import colors from "tailwindcss/colors";
 
 const posts = await getBlogPosts();

--- a/src/pages/pages/[...index].astro
+++ b/src/pages/pages/[...index].astro
@@ -1,6 +1,6 @@
 ---
 import { POSTS_PER_PAGE } from "../../config.ts";
-import { getBlogPosts } from "src/utils";
+import { getBlogPosts } from "../../utils";
 import PostList from "$layouts/PostList.astro";
 
 export async function getStaticPaths() {

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -6,7 +6,7 @@ import Header from "$components/Header.astro";
 import Footer from "$components/Footer.astro";
 import { Image } from "astro:assets";
 import FormattedDate from "$components/FormattedDate.astro";
-import { getBlogPosts } from "src/utils";
+import { getBlogPosts } from "../../utils";
 import Tag from "$components/Tag.astro";
 import { SHOW_IMAGES } from "../../config.ts";
 

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,6 +1,6 @@
 import rss from "@astrojs/rss";
 import { SITE_TITLE, SITE_DESCRIPTION, BASE } from "../config.ts";
-import { getBlogPosts } from "src/utils";
+import { getBlogPosts } from "../utils";
 
 export async function GET(context) {
   const posts = await getBlogPosts();

--- a/src/pages/tags/[...tag]/[...index].astro
+++ b/src/pages/tags/[...tag]/[...index].astro
@@ -1,7 +1,7 @@
 ---
 import { POSTS_PER_PAGE } from "../../../config.ts";
 
-import { getBlogPosts } from "src/utils";
+import { getBlogPosts } from "../../../utils";
 import PostList from "$layouts/PostList.astro";
 
 export async function getStaticPaths() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,14 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "strictNullChecks": true,
-    "baseUrl": ".",
     "paths": {
-      "$lib/*": ["src/lib/*"],
-      "$components/*": ["src/components/*"],
-      "$layouts/*": ["src/layouts/*"],
-      "$pages/*": ["src/pages/*"],
-      "$styles/*": ["src/styles/*"],
-      "$assets/*": ["src/assets/*"],
-      "$examples/*": ["src/examples/*"]
+      "$lib/*": ["./src/lib/*"],
+      "$components/*": ["./src/components/*"],
+      "$layouts/*": ["./src/layouts/*"],
+      "$pages/*": ["./src/pages/*"],
+      "$styles/*": ["./src/styles/*"],
+      "$assets/*": ["./src/assets/*"],
+      "$examples/*": ["./src/examples/*"]
     }
   },
   "exclude": ["public/pagefind", "dist"]


### PR DESCRIPTION
## Summary
- TypeScript 7.0で廃止予定の`baseUrl`を`tsconfig.json`から削除
- `paths`の値に`./`プレフィックスを追加（`baseUrl`なしで動作するため）
- `baseUrl`に依存していた`"src/utils"`・`"src/colors"`インポートを相対パスに修正
- `astro-custom-embeds`の`importPath: "src/embeds"`用にViteエイリアスを追加

## Test plan
- [x] `npm run build`（TypeScriptチェック + Astroビルド + Pagefind）が成功することを確認済み
- [x] CI（format:check + lint）の通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)