### PR TITLE
fix: RSSフィードのブログ記事URLから末尾スラッシュを除去

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -8,9 +8,10 @@ export async function GET(context) {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: context.site + BASE,
+    trailingSlash: false,
     items: posts.map((post) => ({
       ...post.data,
-      link: `${BASE}/posts/${post.id}/`,
+      link: `${BASE}/posts/${post.id}`,
     })),
   });
 }


### PR DESCRIPTION
## Summary
  - `@astrojs/rss` に `trailingSlash: false` を追加し、デフォルトの末尾スラッシュ付与を無効化
  - `link` テンプレートリテラルからも末尾 `/` を削除
  - `astro.config.ts` の `trailingSlash: "never"` と整合性を確保

  ## Test plan
  - [x] `npm run build` が成功する
  - [x] `dist/rss.xml` 内のブログ記事URLに末尾 `/` がない

  🤖 Generated with [Claude Code](https://claude.com/claude-code)